### PR TITLE
Temporal fix to test the rest of the system using the simulator

### DIFF
--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -224,6 +224,7 @@ class TLDetector(object):
             int: ID of traffic light color (specified in styx_msgs/TrafficLight)
 
         """
+        return light.state
 
         if(not self.has_image):
             self.prev_light_loc = None


### PR DESCRIPTION
Quick fix to return the exact state of the traffic light. This will allow to test the rest of the system until we put the classifier onto production